### PR TITLE
contacts based discretization

### DIFF
--- a/adaptivemastermsm/analyzer/analyzer_lib.py
+++ b/adaptivemastermsm/analyzer/analyzer_lib.py
@@ -5,6 +5,7 @@ This file is part of the AdaptiveMasterMSM package.
 
 import sys, os
 import numpy as np
+import scipy.linalg as spla
 import random
 from adaptivemastermsm.launcher import launcher_lib
 
@@ -86,4 +87,3 @@ def list_duplicates_of(seq,item):
             locs.append(loc)
             start_at = loc
     return locs
-


### PR DESCRIPTION
Contacts based discretization is included as a possible 'method' during the adaptive sampling calculation.
It basically calculates pairwise distances between heavy atoms in order to discretize a given trajectory and
build clusters accordingly. The latter requires to discretize parallel trajectories simultaneously.