### PR TITLE
Do adaptive sampling with fictitious trajectories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ travis:
     - develop
 
 install:
-    - python setup.py install --user
+    - python setup.py develop --user
 
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ travis:
     - develop
 
 install:
-    - python setup.py develop --user
+    - python setup.py develop
 
 
 script:

--- a/adaptivemastermsm/analyzer/analyzer_lib.py
+++ b/adaptivemastermsm/analyzer/analyzer_lib.py
@@ -42,8 +42,7 @@ def gen_input_weights(n_msm_runs, labels_all, trajs, tprs):
             which_tr = labels_all[which_tr_index[0]]
             # obtain positions in traj where label 'i' is found
             index = list_duplicates_of(list(which_tr), i)
-            print('ionix',i)
-            print(w[:,i])
+            print('ionix',i,w[:,i])
             if len(index) is 0: break # redundant if 'weigths' works
             j = random.choice(index)
             map_inputs(trajs[which_tr_index[0]].mdt, i, j, inputs, tprs[which_tr_index[0]])
@@ -54,8 +53,10 @@ def gen_input_weights(n_msm_runs, labels_all, trajs, tprs):
 
     return inputs
 
-def map_inputs(traj, label, frame, inputs, tpr):
+def map_inputs(label, frame, inputs, not_run, traj=None, tpr=None):
     """
+
+    Create new .gro input files
         
     Parameters
     ----------
@@ -65,15 +66,20 @@ def map_inputs(traj, label, frame, inputs, tpr):
         Label identifying the initial state of the new input
     frame : int
         Frame corresponding to the initial state for the new input
+    not_run : bool
+        Use already simulated trajectories for epochs
 
     """
 
-    fn = '%s_%s.gro'%(label,frame)
-    inputs.append(fn)
-    tr = 'data/%s_%s.xtc'%(label,frame)
-    traj.save_xtc(tr)
-    cmd = "gmx trjconv -s %s -f %s -o %s -dump %s <<EOF\n1\nEOF"%(tpr, tr, fn, traj.time[frame])
-    os.system(cmd)
+    if not_run:
+        inputs.append([frame,label])
+    else:
+        fn = '%s_%s.gro'%(label,frame)
+        inputs.append(fn)
+        tr = 'data/%s_%s.xtc'%(label,frame)
+        traj.save_xtc(tr)
+        cmd = "gmx trjconv -s %s -f %s -o %s -dump %s <<EOF\n1\nEOF"%(tpr, tr, fn, traj.time[frame])
+        os.system(cmd)
 
 def list_duplicates_of(seq,item):
     start_at = -1

--- a/adaptivemastermsm/controller.py
+++ b/adaptivemastermsm/controller.py
@@ -4,6 +4,7 @@ This file is part of the AdaptiveMasterMSM package.
 """
 # Tools
 import copy
+import h5py
 # Maths
 import numpy as np
 # Plotting
@@ -22,7 +23,7 @@ class Controller(object):
     Driver of the adaptive sampling algorithm
 
     """
-    def __init__(self, pdb, forcefield=None, water=None,\
+    def __init__(self, pdb=None, forcefield=None, water=None,\
                 topology=None, constraints=None, trajfiles=None, tprs=None):
         """
         Iteratively, create a GROMACS file, launch, and analyze.
@@ -50,14 +51,15 @@ class Controller(object):
         self.gro_initial = pdb
         Controller.system = system.System(pdb, forcefield, water,\
                             topology=topology, constraints=constraints)
-        self.top = topology
-        self.sys_prepare(pdb)
 
+        self.top = topology
         if trajfiles is None:
+            self.sys_prepare(pdb)
             self.all_sys_equilibration()
             self.trajfiles = ['%s.xtc'%self.npt.out]
             self.tprs = [self.npt.tpr]
         else:
+            #self.sys_prepare(pdb)
             self.trajfiles = trajfiles
             self.tprs = tprs
 
@@ -109,9 +111,9 @@ class Controller(object):
         self.npt = launcher.Launcher(nvt_system)
         self.sys_equilibrate('npt')
 
-    def adaptive_sampling(self, n_runs, lagt, mcs=85, ms=75, sym=False, rate_mat=True,\
-                            scoring='populations', n_epochs=2, max_time=100000.0,\
-                            method='hdbscan'):
+    def adaptive_sampling(self, n_runs, lagt, mcs=85, ms=15, sym=False, rate_mat=True,    \
+                        scoring='populations', n_epochs=2, nsteps=250000, max_time=100000.0,\
+                        method=None, not_run=False):
         """
         Implementation of the Adaptive Sampling algorithm
 
@@ -131,25 +133,31 @@ class Controller(object):
             Scoring function to use (str): count, popul
         n_epochs : int
             Number of outer loops in AS algorithm
+        nsteps   : int
+            Number of MD steps per epoch
         max_time : int
             Maximum simulation time in ps
+        not_run : bool
+            Use already simulated trajectories for epochs
 
         """
-        # Set options from 'equilibration' calculations
-        forcefield = self.system.ff
-        water = self.system.wat
-        constraints = self.system.cons
-
         n = 0
+        offset = len(self.trajfiles)
         sim_time = 0.0
-        tprs = self.tprs
         while True:
             # ANALYZER #
             self.anal = analyzer.Analyzer(self.trajfiles)
-            if n == 0: offset = len(self.trajfiles)
-            self.anal.build_msm(n, n_runs, lagt, method=method, \
-                mcs=mcs, ms=ms, sym=sym, gro=self.gro_initial, rate_mat=rate_mat, offset=offset)
-            inputs = self.anal.resampler(self.tprs, scoring=scoring)
+            self.anal.build_msm(n, n_runs, lagt, method=method, mcs=mcs, ms=ms,\
+                sym=sym, gro=self.gro_initial, rate_mat=rate_mat, offset=offset)
+            if not_run:
+                inputs = self.anal.resampler(self.tprs, scoring,\
+                                        not_run=True)
+                self.not_run(inputs,nsteps,n) #self.trajfiles
+                n += 1
+                if n > n_epochs: break
+                continue
+            else:
+                inputs = self.anal.resampler(self.tprs, scoring)
             
             n += 1
             if n > n_epochs or sim_time > max_time:
@@ -161,15 +169,15 @@ class Controller(object):
             i = 0
             for gro in inputs:
                 i += 1
-                self.system = system.System(gro, forcefield, water,\
-                            constraints=constraints)#topology=self.top
+                self.system = system.System(gro, self.system.ff, self.system.wat,\
+                            constraints=self.system.cons)#topology=self.top
                 self.sys_prepare(gro)
                 # Set up the simulation box and thermodynamic ensemble
                 self.all_sys_equilibration()
                 tpr, out = 'data/tpr/%s_%s.tpr'%(n, i), 'data/out/%s_%s'%(n, i)
                 launcher_lib.checkfile(tpr)
                 launcher_lib.checkfile(out)
-                self.npt.gen_tpr(mdp='prod', tpr=tpr)#, sim_time=sim_time)
+                self.npt.gen_tpr(mdp='prod', tpr=tpr, nsteps=nsteps)#, sim_time=sim_time)
                 tprs.append(tpr)
                 outs.append(out)
                 self.trajfiles.append('%s.xtc'%out)
@@ -178,4 +186,19 @@ class Controller(object):
             [self.tprs.append(tpr) for tpr in tprs]
             # Run parallel short trajectories
             self.npt.mp_run(tprs, outs)
+
+    def not_run(self, inputs, nsteps, n):
+        """
+        Extract trajectory parts from h5 reference file according to 'inputs'
+
+        """
+        traj = self.anal.data[0]
+        for inp in inputs:
+            print(traj, n, inp[0], inp[1])
+            data = traj[inp[0]:inp[0]+nsteps]
+            # n stands for nepoch and inp[0] for label
+            h5file = "./trajs/cossio_%g_%g.h5"%(n,inp[0])
+            with h5py.File(h5file, "w") as trajectory:
+                trajectory.create_dataset("data", data=data)
+            self.trajfiles.append(h5file)
 

--- a/adaptivemastermsm/launcher/launcher.py
+++ b/adaptivemastermsm/launcher/launcher.py
@@ -29,7 +29,7 @@ class Launcher(object):
         """
         Launcher.system = simsys
 
-    def gen_tpr(self, mdp=None, tpr='data/out.tpr'):#, sim_time=None): #, i, chk=None):
+    def gen_tpr(self, mdp=None, tpr='data/out.tpr', nsteps=250000):#, sim_time=None,chk=None):
         """
         Function for generating tpr files
 
@@ -48,7 +48,6 @@ class Launcher(object):
         #else:
         filemdp = mdp
         emstep = 0.002
-        nsteps = 150000#50000
         if mdp in ["min","nvt","npt","prod"]:
             if mdp is "min": txt = launcher_lib.write_mdp_min()
             if mdp is "nvt": txt = launcher_lib.write_mdp_nvt()


### PR DESCRIPTION
Main changes:

 - Do adaptive sampling exploiting previously simulated long trajectories. The latter is referred to as 'not_run' in the code (mainly controller.py, analyzer.py and analyzer_lib.py). A h5py file with a discrete trajectory as input is required, so that discretization is avoided during adaptive sampling execution.
 - Minor changes related with 'travis' tool, and parameter 'nsteps' in gen_tpr routine from launcher.py.